### PR TITLE
Streamline non-pi user niceties and some fixes for bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Role Variables
 - `webcam_height` : 480
 - `webcam_fps`: 10 (frames per second)
 - `custom_input` : "input_uvc.so" (input parameters to be used with 'custom' webcam type)
+- `webcam_device`: (Optional, not defined by default) Used to specify a device in usb mode, for buggy webcams that present multiple video devices
 
 See https://community.octoprint.org/t/available-mjpg-streamer-configuration-options/1106
 for available custom options.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,6 @@ webcam_user: mjpg_streamer
 webcam_port: 8080
 webcam_type: usb
 webcam_width: 640
-webcam_height: 480 
+webcam_height: 480
 webcam_fps: 10
 custom_input: "input_uvc.so"

--- a/tasks/octoprint.yml
+++ b/tasks/octoprint.yml
@@ -56,7 +56,7 @@
     dest: "{{ install_dir }}/.octoprint/config.yaml"
     owner: "{{ octoprint_user }}"
   when: reset_config
-    
+
 - name: Install init template.
   template:
     src: octoprint.init.j2
@@ -76,17 +76,25 @@
     dest: /etc/systemd/system/octoprint.service
     owner: "{{ octoprint_user }}"
 
-- name: Change ownership of .octoprint directory
-  file:
-    path: "{{ install_dir }}/.octoprint"
-    state: directory
-    recurse: true
-    owner: "{{ octoprint_user }}"
-    group: "{{ octoprint_user }}"
+- name: Add lines to sudoers
+  lineinfile:
+    path: /etc/sudoers
+    state: present
+    line: "{{ item }}"
+    validate: /usr/sbin/visudo -cf %s
+  loop:
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl restart octoprint"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl start octoprint"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl stop octoprint"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl restart mjpg_streamer"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl start mjpg_streamer"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl stop mjpg_streamer"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/sbin/shutdown -r now"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/sbin/shutdown -h now"
 
-- name: Change ownership of Octoprint directory
+- name: Change ownership of install directory
   file:
-    path: "{{ install_dir }}/Octoprint"
+    path: "{{ install_dir }}"
     state: directory
     recurse: true
     owner: "{{ octoprint_user }}"

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -12,6 +12,25 @@
   register: disable_service
   ignore_errors: true
 
+- name: Remove sudoer permissions
+  lineinfile:
+    path: /etc/sudoers
+    state: absent
+    line: "{{ item }}"
+    validate: /usr/sbin/visudo -cf %s
+  loop:
+    - "{{ webcam_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl start mjpg_streamer"
+    - "{{ webcam_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl stop mjpg_streamer"
+    - "{{ webcam_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl restart mjpg_streamer"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl restart octoprint"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl start octoprint"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl stop octoprint"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl restart mjpg_streamer"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl start mjpg_streamer"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl stop mjpg_streamer"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/sbin/shutdown -r now"
+    - "{{ octoprint_user }} ALL=(ALL) NOPASSWD:/usr/sbin/shutdown -h now"
+
 - name: Remove files and directories
   file:
     path: "{{ item }}"

--- a/tasks/webcam.yml
+++ b/tasks/webcam.yml
@@ -42,14 +42,14 @@
 - name: Clone mjpg-streamer repo.
   git:
     repo: "{{ webcam_repo }}"
-    dest: "{{ install_dir }}/mjpg-streamer"
+    dest: "/home/{{ webcam_user }}/mjpg-streamer"
     version: master
-  become_user: "{{ octoprint_user }}"
+  become_user: "{{ webcam_user }}"
   become: yes
 
 - name: Build mjpg-streamer from source.
   make:
-    chdir: "{{ install_dir }}/mjpg-streamer/mjpg-streamer-experimental"
+    chdir: "{{ webcam_dir }}"
     target: all
 
 - name: Install systemd service template.
@@ -60,11 +60,22 @@
 
 - name: Change ownership of mjpg-streamer directory.
   file:
-    path: "{{ install_dir }}/mjpg-streamer"
+    path: "/home/{{ webcam_user }}/mjpg-streamer"
     state: directory
     recurse: true
-    owner: "{{ octoprint_user }}"
-    group: "{{ octoprint_user }}"
+    owner: "{{ webcam_user }}"
+    group: "{{ webcam_user }}"
+
+- name: Add lines to sudoers
+  lineinfile:
+    path: /etc/sudoers
+    state: present
+    line: "{{ item }}"
+    validate: /usr/sbin/visudo -cf %s
+  loop:
+    - "{{ webcam_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl start mjpg_streamer"
+    - "{{ webcam_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl stop mjpg_streamer"
+    - "{{ webcam_user }} ALL=(ALL) NOPASSWD:/usr/bin/systemctl restart mjpg_streamer"
 
 - name: Start webcam streaming service.
   systemd:

--- a/templates/mjpg_streamer.service.j2
+++ b/templates/mjpg_streamer.service.j2
@@ -6,12 +6,12 @@ Wants=network-online.target
 [Service]
 User={{ webcam_user }}
 Environment=LD_LIBRARY_PATH={{ webcam_dir }}
-{% if webcam_type == 'raspi' -%} 
+{% if webcam_type == 'raspi' -%}
 ExecStart={{ webcam_dir }}/mjpg_streamer -o "output_http.so -w {{ webcam_dir }}/www" -i "input_raspicam.so -x {{ webcam_width }} -y {{ webcam_height }} -fps {{ webcam_fps }}"
 {% elif webcam_type == 'custom' -%}
 ExecStart={{ webcam_dir }}/mjpg_streamer -o "output_http.so -w {{ webcam_dir }}/www" -i "{{ custom_input }}"
 {% else -%}
-ExecStart={{ webcam_dir }}/mjpg_streamer -o "output_http.so -w {{ webcam_dir }}/www" -i "input_uvc.so -r {{ webcam_width }}x{{ webcam_height }} -f {{ webcam_fps }}"
+ExecStart={{ webcam_dir }}/mjpg_streamer -o "output_http.so -w {{ webcam_dir }}/www" -i "input_uvc.so {% if webcam_device is defined %} -d /dev/{{webcam_device }} {% endif %} -r {{ webcam_width }}x{{ webcam_height }} -f {{ webcam_fps }}"
 {% endif -%}
 
 [Install]


### PR DESCRIPTION
These are some fixes I implemented on my Ubuntu/RaspberryOS systems for the following problems with custom users and a buggy webcam

- Webcam user couldn't access its executable to start the service when using a custom user (permissions issue)
- Octoprint couldn't restart services or the server when running as a custom user (sudoers issuer)
- Some webcams present multiple video devices which are supposed to be used in different modes, so I added a field to define which device to use (device bug workaround)