### PR TITLE
Fix mjpg_streamer build

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Role Variables
 - `octoprint_port`: 5000
 
 - `webcam_user`: mjpg_streamer
-- `webcam_dir`: "{{ install_dir}}/mjpg-streamer/mjpg-streamer-experimental"
+- `webcam_dir`: "/home/{{ webcam_user }}/mjpg-streamer/mjpg-streamer-experimental"
 - `webcam_port`: 8080
 - `webcam_type` : "usb" (options are 'usb', 'raspi' or 'custom')
 - `webcam_width`: 640

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ latest_octoprint_url: "https://get.octoprint.org/latest"
 webcam_repo: "https://github.com/jacksonliam/mjpg-streamer.git"
 
 install_dir: "/home/{{ octoprint_user }}"
-webcam_dir: "{{ install_dir}}/mjpg-streamer/mjpg-streamer-experimental"
+webcam_dir: "/home/{{ webcam_user }}/mjpg-streamer/mjpg-streamer-experimental"
 
 octoprint_user: pi
 octoprint_port: 5000


### PR DESCRIPTION
# ansible_octoprint Pull Request Template

## Description

After your migration to use a separate mjpg_streamer, there is a miss with the current defaults - the mjpg_streamer build task is running in the wrong dir. Quick fix to set the `webcam_dir` var to the correct value

Fixes # (issue)

## Testing

Please ensure your changes are tested on as wide a variety of target devices as possible, including where possible:

- Raspi Lite OS 32-bit and 64-bit
- Ubuntu Bionic (18.04 lTS), Focal (20.04 LTS) & Jammy (22.04 LTS)
- Ubuntu Kinetic (22.10)
- Debian Bullseye (11)

## Checklist:

- [x ] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x ] I have performed a self-review of my own code.
- [x ] (*if appropriate*) I have cited my documentation source(s).
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [x ] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x ] I understand and acknowledge that the code will be published under a BSD 2-Clause license.
