### PR TITLE
Config change to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ To install OctoPrint with pinned version:
       - semuadmin.octoprint
 ```
 
+To install OctoPrint with pinned interface selected:
+
+```yaml
+
+    - name: Provision OctoPrint and mjpg_streamer on Raspberry Pi OS
+      hosts: your_octoprint_hostname
+      remote_user: pi
+      become: true
+
+      vars:
+        webcam_type: raspi
+        octoprint_nic: 192.168.1.56
+
+      roles:
+      - semuadmin.octoprint
+```
+
 To update OctoPrint, keeping existing configuration and access credentials:
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,4 @@ webcam_width: 640
 webcam_height: 480
 webcam_fps: 10
 custom_input: "input_uvc.so"
+octoprint_nic: {{ ansible_default_ipv4.interface }}

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -17,6 +17,8 @@ plugins:
 printerProfiles:
   default: _default
 server:
+  host: "{{ octoprint_nic }}"
+  port: "{{ octoprint_port }}"
   commands:
     serverRestartCommand: sudo systemctl restart octoprint
     systemRestartCommand: sudo shutdown -r now

--- a/templates/octoprint.default.j2
+++ b/templates/octoprint.default.j2
@@ -12,6 +12,9 @@ OCTOPRINT_USER={{ octoprint_user }}
 # On what port to run daemon, default is 5000
 PORT={{ octoprint_port }}
 
+# On what interface will be the default for octoprint be served from
+HOST={{ octoprint_nic }}
+
 # Path to the OctoPrint executable, you need to set this to match your installation!
 DAEMON={{ install_dir }}/Octoprint/venv/bin/octoprint
 


### PR DESCRIPTION
# ansible_octoprint Pull Request Template

## Description

This small change allows to control the default interface that the octoprint uses, with that usage of "{{ octoprint_nic }}" variable control of the server is possible without requiring manual editing of files

Fixes # (issue)

Gives finer grained control of which interface is used by octoprint server as documented here https://docs.octoprint.org/en/master/configuration/config_yaml.html#server

## Testing

Please ensure your changes are tested on as wide a variety of target devices as possible, including where possible:

- Raspi Lite 64-bit
- Ubuntu  22.04

## Checklist:

- [ x ] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [ x ] I have performed a self-review of my own code.
- [ x ] (*if appropriate*) I have cited my documentation source(s).
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [ ] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x ] I understand and acknowledge that the code will be published under a BSD 2-Clause license.
